### PR TITLE
Get Required property from FieldLink when configuring the content typ…

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
+++ b/src/lib/PnP.Framework/Provisioning/ObjectHandlers/ObjectListInstance.cs
@@ -1632,7 +1632,7 @@ namespace PnP.Framework.Provisioning.ObjectHandlers
                     cts => cts.Include(
                         ct => ct.Id,
                         ct => ct.Name,
-                        ct => ct.FieldLinks.Include(fl => fl.Id, fl => fl.Hidden)
+                        ct => ct.FieldLinks.Include(fl => fl.Id, fl => fl.Hidden, fl => fl.Required)
                     ),
                     searchInSiteHierarchy: true
                     );


### PR DESCRIPTION
…e in a list

Include Required property from FieldLink when configuring the content type in a list. Before this change, were only Id and Hidden properties. If a site column was required in the content type, when the content type was include in the list, that column was set as optional.